### PR TITLE
Cleanup.  Sanity check in setup.  vprint

### DIFF
--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -33,13 +33,14 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            body = "data[Login][owner_name]=admin&data[Login][owner_passwd]=#{credential.private}"
+            cred = Rex::Text.uri_encode(credential.private)
+            body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
             cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version)
             cli.connect
             req = cli.request_cgi(
               'method' => 'POST',
               'uri' => '/UI/login',
-              'data' => Rex::Text.uri_encode(body)
+              'data' => body
             )
             res = cli.send_recv(req)
             if res && res.code == 302 && res.headers['location'] && res.headers['location'].include?('UI')

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -33,10 +33,16 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def setup
+    super
     # They must select at least blank passwords, provide a pass file or a password
     one_required = %w(BLANK_PASSWORDS PASS_FILE PASSWORD)
-    unless one_required.any? { |o| datastore[o] }
+    unless one_required.any? { |o| datastore.has_key?(o) && datastore[o] }
       fail_with(Failure::BadConfig, "Invalid options: One of #{one_required.join(', ')} must be set")
+    end
+    if !datastore['PASS_FILE']
+      if !datastore['BLANK_PASSWORDS'] && datastore['PASSWORD'].blank?
+        fail_with(Failure::BadConfig, "PASSWORD or PASS_FILE must be set to a non-empty string if not BLANK_PASSWORDS")
+      end
     end
   end
 


### PR DESCRIPTION
This:
- Cleans up some ruby style issues, all relatively minor
- Checks for the minimal required options in setup and bails if they are not set (see my comments in #4003)
- `vprint`'s when a login fails, otherwise this will be a mess when run against multiple hosts
